### PR TITLE
For vlc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,9 @@ if(UNIX AND NOT CYGWIN)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/symlink-${ARIBB25_LIB_NAME} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} RENAME arib25)
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DLDCONFIG_EXECUTABLE=${LDCONFIG_EXECUTABLE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PostInstall.cmake)")
 
+	configure_file(aribb25/${ARIBB25_LIB_NAME}.pc.in ${ARIBB25_LIB_NAME}.pc @ONLY)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${ARIBB25_LIB_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 	add_custom_target(uninstall ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Uninstall.cmake)
 
 # ---------- install (Windows) ----------

--- a/aribb25/arib_std_b25.h
+++ b/aribb25/arib_std_b25.h
@@ -52,6 +52,8 @@ typedef struct {
 
 } ARIB_STD_B25;
 
+#define ARIB_STD_B25_TS_PROBING_MIN_DATA (320 * 9 - 1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/aribb25/aribb25.pc.in
+++ b/aribb25/aribb25.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=${prefix}/include
+
+Name: @ARIBB25_LIB_NAME@
+Description: @ARIBB25_DESCRIPTION@
+URL: @ARIBB25_URL@
+Version: @ARIBB25_VERSION_STRING@
+Libs: -L${libdir} -l@ARIBB25_LIB_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
libaribb25 を VLC のビルド時に読みこみ、 VLC 単体で B25 デコードできるようにします。
デコード機能はもともと (いつのまにか) 実装されてはいたものの、あまり知られていません…
(私もついさっき知りました)

1. VLC は aribb25 という名前であることを期待して aribb25 ライブラリを pkg-config で 探しに行くので、別名を追加してしまいました。
2. コンパイル時に必要となる定義があるので追加しています。(ARIB_STD_B25_TS_PROBING_MIN_DATA) 

VLC での動作確認は master (VLC-4.0.0 dev) ブランチで行っています。
別名での追加はポリシー的な問題もあるかと思いますので、 Merge if necessary  でお願いします。