### PR TITLE
MSVCではmulti2.c, multi2_simd.cを、MinGW/Linuxではmulti2.ccを使う

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ link_directories(${PCSC_LIBRARY_DIRS})
 
 # ---------- libaribb1 ----------
 
-if(WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(ARM|ARM64|AARCH64)")
+if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
 	add_library(aribb1-objlib OBJECT aribb25/arib_std_b25.c aribb25/b_cas_card.c aribb25/multi2.c aribb25/multi2_simd.c aribb25/ts_section_parser.c aribb25/version_b1.c)
 else()
 	add_library(aribb1-objlib OBJECT aribb25/arib_std_b25.c aribb25/b_cas_card.c aribb25/multi2.cc aribb25/ts_section_parser.c aribb25/version_b1.c)
@@ -186,7 +186,7 @@ configure_file(aribb25/version_b1.rc.in version_b1.rc @ONLY)
 
 # ---------- libaribb25 ----------
 
-if(WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(ARM|ARM64|AARCH64)")
+if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
 	add_library(aribb25-objlib OBJECT aribb25/arib_std_b25.c aribb25/b_cas_card.c aribb25/multi2.c aribb25/multi2_simd.c aribb25/ts_section_parser.c aribb25/version_b25.c)
 else()
 	add_library(aribb25-objlib OBJECT aribb25/arib_std_b25.c aribb25/b_cas_card.c aribb25/multi2.cc aribb25/ts_section_parser.c aribb25/version_b25.c)

--- a/aribb25/multi2.h
+++ b/aribb25/multi2.h
@@ -20,7 +20,7 @@ typedef struct {
 	int (* clear_scramble_key)(void *m2);
 
 	int (* encrypt)(void *m2, int32_t type, uint8_t *buf, int32_t size);
-#ifdef ENABLE_MULTI2_SIMD
+#if defined(_MSC_VER)
 	int (* decrypt)(void *m2, int32_t type, uint8_t *buf, intptr_t size);
 #else
 	int (* decrypt)(void *m2, int32_t type, uint8_t *buf, int32_t size);


### PR DESCRIPTION
kazuki0824/recisdb-rs#115

関数ポインタ `decrypt` へ格納する関数 `decrypt_multi2()` は multi2.c と multi2.cc にあり CMakeLists.txt でファイルを切り替えていますが、multi2.h にある切り替え条件が一致していません。

ビルド確認はしていません。